### PR TITLE
Score debugging

### DIFF
--- a/index.js
+++ b/index.js
@@ -244,7 +244,7 @@ function getCardFromStock(pile, event){
     }
     talonPile.appendChild(stockPileCard);
     stockPileCard.classList.add("up");
-  }else{ // stockPile empty
+  }else if(scoreType == NORMALSCORING){ // stockPile empty
     addToScore(STOCK);
     //make a button to get every card from talon pile to stack 
     while (talonPile.hasChildNodes()) { 
@@ -253,6 +253,9 @@ function getCardFromStock(pile, event){
       talonPile.lastChild.classList.remove("up");
       stockPile.appendChild(talonPile.removeChild(talonPile.lastChild));
     }
+  } else {
+    // Lose/play again message
+    // Redeal
   }
 } 
 

--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ function clearPiles() {
 
 // add a click event listener to the tableau piles
 function attachEventListeners() {
-  var piles = document.querySelectorAll(".tableau-pile,.foundations-pile");
+  var piles = document.querySelectorAll(".foundations-pile");
   Array.prototype.forEach.call(piles, function (pile) {
     pile.addEventListener("click", function (event) {
       moveCardToTableau(pile, event);
@@ -268,16 +268,16 @@ function getCardFromStock(pile, event){
  *   TALON PILE MOVES  
  */
 
- function attachEventListenersToTalon() {
-  var piles = document.querySelectorAll(".talon-pile");
-  Array.prototype.forEach.call(piles, function (pile) {
-    pile.addEventListener("click", function (event) {
-      moveCardToTableau(pile, event);
-    });
-  });
-}
+//  function attachEventListenersToTalon() {
+//   var piles = document.querySelectorAll(".talon-pile");
+//   Array.prototype.forEach.call(piles, function (pile) {
+//     pile.addEventListener("click", function (event) {
+//       moveCardToTableau(pile, event);
+//     });
+//   });
+// }
 
-attachEventListenersToTalon();
+// attachEventListenersToTalon();
 
 // function moveCardToTalon(pile, event){
 //   console.log('Talon:: pile', pile)
@@ -310,7 +310,7 @@ function isDoubleClick() {
   }
 }
 
-function attachDoubleClickEventListeners() {
+function attachClickEventListeners() {
   var piles = document.querySelectorAll(".tableau-pile,.talon-pile");
   Array.prototype.forEach.call(piles, function (pile) {
     pile.addEventListener("click", function (event) {
@@ -318,12 +318,16 @@ function attachDoubleClickEventListeners() {
     });
   });
 }
-attachDoubleClickEventListeners();
+attachClickEventListeners();
 
 
 // Doubble click pt.2 AKA magicMove
 function magicMove(pile, event,isDoubleClicked){
-  if(isDoubleClicked){
+
+  // Check if the same pile was double clicked
+  // This check is required as rapidly clicking two different piles fulfills a 'double click'
+  // Run double click logic
+  if(isDoubleClicked && pile.lastChild && pile.lastChild.classList.contains("selected")){
     let cardSelected =  event.target;
     if(cardSelected.nextSibling !== null) return;
     let suit = cardSelected.getAttribute("data-suit");
@@ -341,6 +345,9 @@ function magicMove(pile, event,isDoubleClicked){
         moveTableauToFoundation(cardSelected, foundationsPile)
       }
     }
+  }
+  else { // Not a double click, run regular click logic
+    moveCardToTableau(pile, event)
   }
 }
 
@@ -362,26 +369,11 @@ function moveTableauToFoundation(cardSelected, destPile){
     parentPile.lastChild.classList.add("up");
   }
   destPile.appendChild(cardSelected);
-  cardSelected.classList.remove("selected");
-}
-
-
-// add a click event listener to the tableau piles
-function attachEventListeners() {
-  var piles = document.querySelectorAll(".tableau-pile,.foundations-pile");
-  Array.prototype.forEach.call(piles, function (pile) {
-    pile.addEventListener("click", function (event) {
-      moveCardToTableau(pile, event);
-    });
-  });
+  destPile.lastChild.classList.remove("selected");
+  isSelected = false;
 }
 
 /////////
-
-
-
-
-
 
 // function to move cards to the tableau
 //Main variables pile (current or destination  pile which is clicked), parentPile(pile of card having last child class = selected)

--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ function addToScore(eventType) {
 
 function win() {
   addToScore(SCOREGAMEOVER);
-  console.log("game length (s): " + gameLength);
+  clearInterval(scoreTimer);
 }
 
 function checkWin() {
@@ -245,7 +245,9 @@ function getCardFromStock(pile, event){
     talonPile.appendChild(stockPileCard);
     stockPileCard.classList.add("up");
   }else if(scoreType == NORMALSCORING){ // stockPile empty
-    addToScore(STOCK);
+    if(stockPile.hasChildNodes){
+      addToScore(STOCK);
+    }
     //make a button to get every card from talon pile to stack 
     while (talonPile.hasChildNodes()) { 
       talonPile.lastElementChild.classList.remove("selected");
@@ -254,6 +256,7 @@ function getCardFromStock(pile, event){
       stockPile.appendChild(talonPile.removeChild(talonPile.lastChild));
     }
   } else {
+    clearInterval(scoreTimer);
     // Lose/play again message
     // Redeal
   }
@@ -371,6 +374,9 @@ function moveTableauToFoundation(cardSelected, destPile){
   destPile.appendChild(cardSelected);
   destPile.lastChild.classList.remove("selected");
   isSelected = false;
+  if(checkWin()) {
+    win();
+  }
 }
 
 /////////
@@ -453,7 +459,7 @@ function moveCardToTableau(pile, event) { //tableau pile
     for (i = 0; i < cardsSelected.length; i++) {
       cardsSelected[i].classList.remove("selected");
     }
-
+    clickCount = 0;
     isSelected = false;
 
     if(checkWin()) {

--- a/index.js
+++ b/index.js
@@ -6,11 +6,12 @@ const ranks = ["A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"]
 // scoring types
 const NORMALSCORING = 0, VEGASSCORING = 1;
 // scoring event types
-const SCORETABLEAU = 1, SCORETALON = 2, SCOREFOUNDATION = 3, SCOREGAMEOVER = 4, SCORE10S = 5;
+const SCORETABLEAU = 1, SCORETALON = 2, SCOREFOUNDATION = 3, SCOREGAMEOVER = 4, SCORE10S = 5, STOCK = 6;
 var scoreType = NORMALSCORING;
 var isSelected = false;
 var startTime = new Date().getTime();
-var tenSecondScoreTimer = function() {addToScore(SCORE10S);}
+var scoreTimer;
+var scoreTimerFunction = function() {addToScore(SCORE10S);}
 
 d = createDeck();
 //console.log(d);
@@ -98,7 +99,7 @@ var btn = document
     }
   });
 
-// Takes resets current score and updates the startTime timestamp
+// Resets current score and updates the startTime timestamp
 function resetScore() {
   var score = document.querySelector(".score");
   if(scoreType == VEGASSCORING) {
@@ -108,7 +109,8 @@ function resetScore() {
     score.innerHTML = "0";
   }
   startTime = new Date().getTime();
-  tenSecondScoreTimer = setInterval(tenSecondScoreTimer, 10000);
+  clearInterval(scoreTimer);
+  scoreTimer = setInterval(scoreTimerFunction, 10000);
 }
 
 // Alter score by a specific amount based on the score event and scoring type active
@@ -118,28 +120,38 @@ function resetScore() {
 // 3: card moved to foundation    10          5
 // 4: game ended                 bonus
 // 5: 10s elapsed                 -2
+// 6: Stock refresh               -100        lose!
 function addToScore(eventType) {
   var amount = 0;
   if(scoreType == NORMALSCORING) {
     switch(eventType) {
       case SCORETABLEAU:
         amount = 5;
+        // console.log("+5: Tableau");
         break;
       case SCORETALON:
         amount = 5;
+        // console.log("+5: Talon");
         break;
       case SCOREFOUNDATION:
         amount = 10;
+        // console.log("+10: Foundation");
         break;
       case SCOREGAMEOVER:
         // Add [700,000 / (seconds to win the game)] bonus points
         var gameLength = (new Date().getTime() - startTime) / 1000;
-        amount = Math.round(700000 / gameLength)
+        amount = Math.round(700000 / gameLength);
+        // console.log("+"+amount+": GameOver");
         break;
       case SCORE10S:
         amount = -2;
+        // console.log("-2: Timer");
+        break;
+      case STOCK:
+        amount = -100;
         break;
       default:
+        // console.log("0: Default");
         amount = 0;
     }
   }
@@ -147,6 +159,9 @@ function addToScore(eventType) {
     switch(eventType) {
       case SCOREFOUNDATION:
         amount = 5;
+        break;
+      case STOCK:
+        // Lose!
         break;
       default:
         amount = 0;
@@ -229,7 +244,8 @@ function getCardFromStock(pile, event){
     }
     talonPile.appendChild(stockPileCard);
     stockPileCard.classList.add("up");
-  }else{
+  }else{ // stockPile empty
+    addToScore(STOCK);
     //make a button to get every card from talon pile to stack 
     while (talonPile.hasChildNodes()) { 
       talonPile.lastElementChild.classList.remove("selected");
@@ -330,11 +346,20 @@ function moveTableauToFoundation(cardSelected, destPile){
   parentPile = cardSelected.closest(".tableau-pile,.talon-pile");
   console.log("ParentPile",parentPile);
   parentPile.removeChild(cardSelected);
-  
+  if(parentPile.classList.contains("talon-pile")) {
+    addToScore(SCORETALON);
+  }
+  if(destPile.classList.contains("foundations-pile")) {
+    addToScore(SCOREFOUNDATION);
+  }
   if (parentPile.lastChild) {
+    if(!parentPile.lastChild.classList.contains("up")) {
+      addToScore(SCORETABLEAU);
+    }
     parentPile.lastChild.classList.add("up");
   }
   destPile.appendChild(cardSelected);
+  cardSelected.classList.remove("selected");
 }
 
 
@@ -405,10 +430,11 @@ function moveCardToTableau(pile, event) { //tableau pile
       if(pile.classList.contains("foundations-pile")) {
         addToScore(SCOREFOUNDATION);
       }
+
       // Score 5 points when moving from the talon pile
-      // if(*card is from parent pile*) {
-      //   addToScore(SCORETALON);
-      // }
+      if(parentPile.classList.contains("talon-pile")) {
+        addToScore(SCORETALON);
+      }
 
       // remove cardSelected from the old parent pile
       for (i = 0; i < cardsSelected.length; i++) {
@@ -416,9 +442,11 @@ function moveCardToTableau(pile, event) { //tableau pile
       }
       // open the last card left in that pile (if any)
       if (parentPile.lastChild) {
+        if(!parentPile.lastChild.classList.contains("up")) {
+          // New card turned face up, add 5 to score
+          addToScore(SCORETABLEAU);
+        }
         parentPile.lastChild.classList.add("up");
-        // New card turned face up, add 5 to score
-        addToScore(SCORETABLEAU);
       }
       // add cardSelected to the end of the new pile
       for (i = 0; i < cardsSelected.length; i++) {


### PR DESCRIPTION
**Major Changes:**
- Double clicking a talon or tableau pile was causing issues as both events would trigger at once. Card would be moved by one method, causing the other method to throw an error as the card that triggered the move was no longer there. Condensed functionality of event listeners into a single event by the following logic:
       - running a double click event only if a double click was made
       - otherwise, run a normal click event
       - clicking on a foundation pile always runs a normal click event
- Removed duplicate attachEventListeners function; I assume this was copy/pasted for easy reference while creating the moveTableauToFoundation method
- Fully implemented Draw-1 normal scoring, score timer not resetting bug is quashed

**Minor Changes:**
- Cleaned up some comments
- Added additional scoring event: stock pile refresh
- Added commented-out trigger for ending a vegas-style game upon redealing the stock
- Commented-out old eventListener method; did not delete in case it is needed for reference
- Renamed 'attachDoubleClickEventListeners' method to 'attachClickEventListeners' to reflect its new functionality + updated references
- Added checks to stop point gain when moving a card from one face-up stack to another!
